### PR TITLE
Track clicked messages in demo page

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,13 +248,17 @@
     ];
     
     let contadorClicks = 0;
+    const indicesClickeados = new Set();
     
     function mostrarMensaje(indice) {
       const mensajeDiv = document.getElementById('mensaje');
       mensajeDiv.innerHTML = mensajes[indice];
       mensajeDiv.classList.add('mostrar');
-      
-      contadorClicks++;
+
+      if (!indicesClickeados.has(indice)) {
+        indicesClickeados.add(indice);
+        contadorClicks++;
+      }
       if (contadorClicks === mensajes.length) {
         document.getElementById('corazon-final').style.display = 'block';
         // Activar confeti cuando se muestran todos los mensajes
@@ -273,6 +277,7 @@
       document.getElementById('mensaje').innerHTML = '';
       document.getElementById('mensaje').classList.remove('mostrar');
       contadorClicks = 0;
+      indicesClickeados.clear();
       document.getElementById('corazon-final').style.display = 'none';
     }
     


### PR DESCRIPTION
## Summary
- avoid counting repeated clicks on flowers
- reset click tracking on reset

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b6c7692fc832aa6b7ba180a3ccc96