### PR TITLE
Fix accent in first message

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,7 +239,7 @@
   <script>
     // Array de mensajes
     const mensajes = [
-      "Por tu sonrisa que me vuelve loco, en la cúal jamás dejo de pensar, la sonrisa más y única preciosa que existe 🌞",
+      "Por tu sonrisa que me vuelve loco, en la cual jamás dejo de pensar, la sonrisa más y única preciosa que existe 🌞",
       "Por la enorme inteligencia que reside en ti, es impresionante ver como resuelves los problemas y siempre sales adelante de todos ellos mi amor ✨",
       "Por tu corazón bondadoso y empático que siempre procura el bienestar de los demás 🥰",
       "Por las aventuras que hemos vivido y las que nos faltan por vivir, juntos hasta el fin del universo mi cielo 🌍",


### PR DESCRIPTION
## Summary
- fix a typo in `index.html` by changing `cúal` to `cual`

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685b6c74ec90832a87695dfd632acd4e